### PR TITLE
Retry all non 400/401/403 errors instead of only 500s

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://img.shields.io/coveralls/github/octokit/plugin-retry.js.svg)](https://coveralls.io/github/octokit/plugin-retry.js)
 [![Greenkeeper](https://badges.greenkeeper.io/octokit/plugin-retry.js.svg)](https://greenkeeper.io/)
 
-Implements request retries for server error responses.
+Implements request retries for server 4xx/5xx responses except `400`, `401`, `403` and `404`.
 
 ## Usage
 
@@ -25,7 +25,17 @@ octokit.request('/').catch(error => {
 })
 ```
 
-You can ask for retries for any request by passing `{ request: { retries: numRetries, retryAfter: delayInSeconds }}`
+To override the default `doNotRetry` list:
+
+```js
+const octokit = new Octokit({
+  retry: {
+    doNotRetry: [ /* List of HTTP 4xx/5xx status codes */ ]
+  }
+})
+```
+
+You can manually ask for retries for any request by passing `{ request: { retries: numRetries, retryAfter: delayInSeconds }}`
 
 ```js
 octokit.request('/', { request: { retries: 1, retryAfter: 1 } }).catch(error => {

--- a/lib/error-request.js
+++ b/lib/error-request.js
@@ -1,7 +1,8 @@
 module.exports = errorRequest
 
 async function errorRequest (octokit, state, error, options) {
-  if (!state.doNotRetry.includes(error.status)) {
+  // retry all >= 400 && not doNotRetry
+  if (error.status >= 400 && !state.doNotRetry.includes(error.status)) {
     const retries = options.request.retries != null ? options.request.retries : state.retries
     const retryAfter = Math.pow((options.request.retryCount || 0) + 1, 2)
     throw octokit.retry.retryRequest(error, retries, retryAfter)

--- a/lib/error-request.js
+++ b/lib/error-request.js
@@ -1,17 +1,13 @@
 module.exports = errorRequest
 
-async function errorRequest (octokit, error, options) {
-  if (error.status === 500) {
-    const retries = 3
+async function errorRequest (octokit, state, error, options) {
+  if (!state.doNotRetry.includes(error.status)) {
+    const retries = options.request.retries != null ? options.request.retries : state.retries
     const retryAfter = Math.pow((options.request.retryCount || 0) + 1, 2)
     throw octokit.retry.retryRequest(error, retries, retryAfter)
   }
 
-  /*
-    TODO:
-    Add more cases here.
-    Use the 500 error above as example.
-  */
+  // Maybe eventually there will be more cases here
 
   throw error
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,13 +3,14 @@ module.exports = retryPlugin
 const wrapRequest = require('./wrap-request')
 const errorRequest = require('./error-request')
 
-function retryPlugin (octokit) {
-  const state = {
-    retryAfterBaseValue: 1000
-  }
+function retryPlugin (octokit, octokitOptions = {}) {
+  const state = Object.assign({
+    retryAfterBaseValue: 1000,
+    doNotRetry: [ 400, 401, 403 ],
+    retries: 3
+  }, octokitOptions.retry)
 
   octokit.retry = {
-    _options: (options = {}) => Object.assign(state, options),
     retryRequest: (error, retries, retryAfter) => {
       error.request.request.retries = retries
       error.request.request.retryAfter = retryAfter
@@ -17,6 +18,6 @@ function retryPlugin (octokit) {
     }
   }
 
-  octokit.hook.error('request', errorRequest.bind(null, octokit))
+  octokit.hook.error('request', errorRequest.bind(null, octokit, state))
   octokit.hook.wrap('request', wrapRequest.bind(null, state))
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const errorRequest = require('./error-request')
 function retryPlugin (octokit, octokitOptions = {}) {
   const state = Object.assign({
     retryAfterBaseValue: 1000,
-    doNotRetry: [ 400, 401, 403 ],
+    doNotRetry: [ 400, 401, 403, 404 ],
     retries: 3
   }, octokitOptions.retry)
 

--- a/lib/wrap-request.js
+++ b/lib/wrap-request.js
@@ -11,6 +11,8 @@ async function wrapRequest (state, request, options) {
     options.request.retryCount = info.retryCount + 1
 
     if (maxRetries > info.retryCount) {
+      // Returning a number instructs the limiter to retry
+      // the request after that number of milliseconds have passed
       return after * state.retryAfterBaseValue
     }
   })

--- a/test/backend-errors.js
+++ b/test/backend-errors.js
@@ -3,8 +3,7 @@ const Octokit = require('./octokit')
 
 describe('Trigger Retries', function () {
   it('Should trigger exponential retries on HTTP 500 errors', async function () {
-    const octokit = new Octokit()
-    octokit.retry._options({ retryAfterBaseValue: 50 })
+    const octokit = new Octokit({ retry: { retryAfterBaseValue: 50 } })
 
     const res = await octokit.request('GET /route', {
       request: {
@@ -26,8 +25,62 @@ describe('Trigger Retries', function () {
       'START GET /route',
       'END GET /route'
     ])
-    expect(octokit.__requestTimings[1] - octokit.__requestTimings[0]).to.be.closeTo(50, 15)
-    expect(octokit.__requestTimings[2] - octokit.__requestTimings[1]).to.be.closeTo(200, 15)
-    expect(octokit.__requestTimings[3] - octokit.__requestTimings[2]).to.be.closeTo(450, 15)
+    expect(octokit.__requestTimings[1] - octokit.__requestTimings[0]).to.be.closeTo(50, 20)
+    expect(octokit.__requestTimings[2] - octokit.__requestTimings[1]).to.be.closeTo(200, 20)
+    expect(octokit.__requestTimings[3] - octokit.__requestTimings[2]).to.be.closeTo(450, 20)
+  })
+
+  it('Should not retry 400/401/403 errors', async function () {
+    const octokit = new Octokit({ retry: { retryAfterBaseValue: 50 } })
+    let caught = 0
+
+    try {
+      await octokit.request('GET /route', {
+        request: {
+          responses: [
+            { status: 400, headers: {}, data: { message: 'Error 400' } },
+            { status: 500, headers: {}, data: { message: 'Error 500' } }
+          ]
+        }
+      })
+    } catch (error) {
+      expect(error.message).to.equal('Error 400')
+      caught++
+    }
+
+    try {
+      await octokit.request('GET /route', {
+        request: {
+          responses: [
+            { status: 401, headers: {}, data: { message: 'Error 401' } },
+            { status: 500, headers: {}, data: { message: 'Error 500' } }
+          ]
+        }
+      })
+    } catch (error) {
+      expect(error.message).to.equal('Error 401')
+      caught++
+    }
+
+    try {
+      await octokit.request('GET /route', {
+        request: {
+          responses: [
+            { status: 403, headers: {}, data: { message: 'Error 403' } },
+            { status: 500, headers: {}, data: { message: 'Error 500' } }
+          ]
+        }
+      })
+    } catch (error) {
+      expect(error.message).to.equal('Error 403')
+      caught++
+    }
+
+    expect(caught).to.equal(3)
+    expect(octokit.__requestLog).to.deep.equal([
+      'START GET /route',
+      'START GET /route',
+      'START GET /route'
+    ])
   })
 })

--- a/test/octokit.js
+++ b/test/octokit.js
@@ -14,7 +14,7 @@ module.exports = Octokit
       await new Promise(resolve => setTimeout(resolve, 0))
 
       const res = options.request.responses.shift()
-      if (res.status >= 400) {
+      if (res.status >= 300) {
         const message = res.data.message != null ? res.data.message : `Test failed request (${res.status})`
         const error = new HttpError(message, res.status, res.headers, options)
         throw error


### PR DESCRIPTION
BREAKING CHANGE: Now retrying all non 400/401/403 errors instead of only 500s