### PR TITLE
fix: handle "Error: Cannot set property 'retries' of undefined"

### DIFF
--- a/lib/error-request.js
+++ b/lib/error-request.js
@@ -1,6 +1,11 @@
 module.exports = errorRequest
 
 async function errorRequest (octokit, state, error, options) {
+  if (!error.request || !error.request.request) {
+    // address https://github.com/octokit/plugin-retry.js/issues/8
+    throw error
+  }
+
   // retry all >= 400 && not doNotRetry
   if (error.status >= 400 && !state.doNotRetry.includes(error.status)) {
     const retries = options.request.retries != null ? options.request.retries : state.retries


### PR DESCRIPTION
closes #8

I don’t add tests yet because I don’t yet understand how error.request or error.request.request cannot be set. It might be an entirely unrelated problem, maybe in WIP’s own code base. Once I see the actual error coming up I’ll update amend this change