### PR TITLE
Improve documentation of `retries`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ const octokit = new Octokit({
 })
 ```
 
+To override the number of retries:
+
+```js
+const octokit = new Octokit({
+  request: { retries: 1 }
+})
+```
+
 You can manually ask for retries for any request by passing `{ request: { retries: numRetries, retryAfter: delayInSeconds }}`
 
 ```js


### PR DESCRIPTION
I spent a lot of time trying to figure out how to alter the number of retry attempts. Its referenced when passed to a specific request but its not clear that it works in the octokit instance config. 

I tried to do the same with retryAfter and failed.