### PR TITLE
test: increase test coverage to 100

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "preset": "ts-jest",
     "coverageThreshold": {
       "global": {
-        "statements": 98,
-        "branches": 85,
+        "statements": 100,
+        "branches": 100,
         "functions": 100,
-        "lines": 98
+        "lines": 100
       }
     }
   },

--- a/test/octokit.ts
+++ b/test/octokit.ts
@@ -31,4 +31,5 @@ function testPlugin(octokit: Octokit) {
   });
 }
 
+export const TestOctokitWithoutRetry = Octokit.plugin(testPlugin);
 export const TestOctokit = Octokit.plugin(testPlugin, retry);

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -311,7 +311,11 @@ describe("errorRequest", function () {
         request: {},
       },
     };
-    const error = new RequestError("Internal server error", 500, errorOptions) as any;
+    const error = new RequestError(
+      "Internal server error",
+      500,
+      errorOptions
+    ) as any;
     delete error.request;
 
     try {


### PR DESCRIPTION
Hey @gr2m 👋  I took a shot at bringing the test coverage to 100.

This adds three new test cases that cover edge cases in error-request.ts
and index.ts. These in particular cover
* throwing an error if error.request is undefined
* overriding the state.retries property with the options.request.retries
  in errorRequest().
* asserting that the plugin uses the default options when no options
  argument is passed to it.

Fixes #42 