### PR TITLE
docs: Add the missing 422 to "no retry"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plugin-retry.js
 
-> Retries requests for server 4xx/5xx responses except `400`, `401`, `403` and `404`.
+> Retries requests for server 4xx/5xx responses except `400`, `401`, `403`, `404`, and `422`.
 
 [![@latest](https://img.shields.io/npm/v/@octokit/plugin-retry.svg)](https://www.npmjs.com/package/@octokit/plugin-retry)
 [![Build Status](https://github.com/octokit/plugin-retry.js/workflows/Test/badge.svg)](https://github.com/octokit/plugin-retry.js/actions?workflow=Test)


### PR DESCRIPTION
The readme is missing `422` in the list of status code that the plugin will not retry on. This patch adds it there.