### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - "10"
-          - "12"
-          - "14"
-          - "16"
+          - 14
+          - 16
+          - 18
     steps:
       - uses: actions/checkout@v3
       - name: "Use Node.js ${{ matrix.node_version }}"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "14"
+        }
       ],
       [
         "@pika/plugin-build-web"
@@ -90,5 +93,8 @@
     "extends": [
       "github>octokit/.github"
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12