### PR TITLE
fix: make graphql error retries actually work

### DIFF
--- a/src/error-request.ts
+++ b/src/error-request.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 
-export async function errorRequest(octokit, state, error, options) {
+export async function errorRequest(state, octokit, error, options) {
   if (!error.request || !error.request.request) {
     // address https://github.com/octokit/plugin-retry.js/issues/8
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,8 @@ export function retry(octokit: Octokit, octokitOptions: any) {
   );
 
   if (state.enabled) {
-    octokit.hook.error("request", errorRequest.bind(null, octokit, state));
-    octokit.hook.wrap("request", wrapRequest.bind(null, state));
+    octokit.hook.error("request", errorRequest.bind(null, state, octokit));
+    octokit.hook.wrap("request", wrapRequest.bind(null, state, octokit));
   }
 
   return {

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -426,7 +426,7 @@ describe("errorRequest", function () {
     delete error.request;
 
     try {
-      await errorRequest(octokit, state, error, errorOptions);
+      await errorRequest(state, octokit, error, errorOptions);
       expect(1).not.toBe(1);
     } catch (e: any) {
       expect(e).toBe(error);
@@ -454,7 +454,7 @@ describe("errorRequest", function () {
     const error = new RequestError("Internal server error", 500, errorOptions);
 
     try {
-      await errorRequest(octokit, state, error, errorOptions);
+      await errorRequest(state, octokit, error, errorOptions);
       expect(1).not.toBe(1);
     } catch (e: any) {
       expect(e.request.retries).toBe(5);


### PR DESCRIPTION
This is really just a refactoring, I didn't touch tests besides reordering the order of `state, octokit` arguments for consistency. But for some reason the retries didn't work when the `retry` plugin was used with `octokit`. With this change, it does. It's also more efficient because it calls the error handler directly instead of throwing an error and assuming it will be caught and handled correctly.

I confirmed this is working with our production app.