### PR TITLE
Add script to fix package json from build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: "Fix pkg.files file pattern"
+        run: node scripts/fix-package-json.js
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/fix-package-json.js
+++ b/scripts/fix-package-json.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+const {EOL} = require("os");
+
+const pkgPath = path.join(__dirname, "../pkg/package.json");
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+
+pkg.files = pkg.files.map((file) => {
+  if (file.endsWith("/")) {
+    return file + "**";
+  }
+  return file;
+});
+
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + EOL, "utf8");


### PR DESCRIPTION
Resolves #405

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
The released npm package is missing most of the files generated by the build step. `dist-node`, `dist-types`, `dist-web`... even though they are generated correctly.

You can read more about my explanation in the linked issue.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
I expected npm to read the file patterns correctly so we publish all the necessary files again.


### Other information
This is a mix of an issue with `npm@v9` (https://github.com/npm/cli/issues/6164) and the fact we rely on `pika` for the build step. Pika has been archived [since April 2022](https://github.com/FredKSchott/pika-pack) so there is nothing we can do with Pika.

I'm opening a discussion to discuss what we should do: https://github.com/octokit/octokit.js/discussions/2403

## Open questions

If we agree on this solution, we need to plan:
- How to merge and release this?
- What do we do with the rest of the repositories?
- What do we do with the already published versions with missing files?

----

## Additional info

### Pull request checklist
Because this is kind of a temporary hack, do you think I should add tests + documentation for this?

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
No

### Pull request type
Because of the problems is giving to users, I'm treating it as a bug: `Type: Bug`. In terms of semantic commit, let me know if I need to change `ci()` to `fix()`

----

