### PR TITLE
feat: allow strategies other than polynomial

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ const octokit = new MyOctokit({
 });
 ```
 
+To override the retry strategy:
+
+```js
+const octokit = new MyOctokit({
+  auth: "secret123",
+  retry: {
+    // retry strategy, can be one of `exponential`, `linear`, or `polynomial`
+    // defaults to `polynomial`
+    strategy: "polynomial",
+  },
+});
+```
+
 You can manually ask for retries for any request by passing `{ request: { retries: numRetries, retryAfter: delayInSeconds }}`. Note that the `doNotRetry` option from the constructor is ignored in this case, requests will be retried no matter their response code.
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,12 @@ import { wrapRequest } from "./wrap-request";
 
 export const VERSION = "0.0.0-development";
 
+export enum RetryStrategy {
+  exponential = "exponential",
+  linear = "linear",
+  polynomial = "polynomial",
+}
+
 export function retry(octokit: Octokit, octokitOptions: any) {
   const state = Object.assign(
     {
@@ -13,9 +19,14 @@ export function retry(octokit: Octokit, octokitOptions: any) {
       retryAfterBaseValue: 1000,
       doNotRetry: [400, 401, 403, 404, 422],
       retries: 3,
+      strategy: RetryStrategy.polynomial,
     },
     octokitOptions.retry
   );
+
+  if (!RetryStrategy.hasOwnProperty(state.strategy)) {
+    throw new Error(`Invalid retry strategy: ${state.strategy}`);
+  }
 
   if (state.enabled) {
     octokit.hook.error("request", errorRequest.bind(null, state, octokit));


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER (_not applicable; issue does not exist_)

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The plugin always performs retries using polynomial strategy (`RETRY_AFTER_BASE * (RETRY_COUNT + 1)^2`)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The plugin accepts `strategy` as an option.
* The accepted values are
    * `exponential` (`RETRY_AFTER_BASE * 2^(RETRY_COUNT + 1)`)
    * `linear` (`RETRY_AFTER_BASE * (RETRY_COUNT + 1)`)
    * `polynomial` (`RETRY_AFTER_BASE * (RETRY_COUNT + 1)^2`)
* If no strategy is provided, the plugin uses `polynomial` strategy (backwards compatible).
* The plugins throws an error if an invalid strategy name is provided. 

### Other information
<!-- Any other information that is important to this PR  -->

* _not applicable_

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No (I think it should fall under _Adding optional parameters to existing SDK APIs_)

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

- Feature/model/API additions: `Type: Feature`

----

