### PR TITLE
fix: Do not retry status code 451 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plugin-retry.js
 
-> Retries requests for server 4xx/5xx responses except `400`, `401`, `403`, `404`, and `422`.
+> Retries requests for server 4xx/5xx responses except `400`, `401`, `403`, `404`, `422`, and `451`.
 
 [![@latest](https://img.shields.io/npm/v/@octokit/plugin-retry.svg)](https://www.npmjs.com/package/@octokit/plugin-retry)
 [![Build Status](https://github.com/octokit/plugin-retry.js/workflows/Test/badge.svg)](https://github.com/octokit/plugin-retry.js/actions?workflow=Test)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export function retry(octokit: Octokit, octokitOptions: any) {
     {
       enabled: true,
       retryAfterBaseValue: 1000,
-      doNotRetry: [400, 401, 403, 404, 422],
+      doNotRetry: [400, 401, 403, 404, 422, 451],
       retries: 3,
     },
     octokitOptions.retry

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -205,10 +205,10 @@ describe("Automatic Retries", function () {
     expect(ms2).toBeGreaterThan(420);
   });
 
-  it("Should not retry 3xx/400/401/403/422 errors", async function () {
+  it("Should not retry 3xx/400/401/403/422/451 errors", async function () {
     const octokit = new TestOctokit({ retry: { retryAfterBaseValue: 50 } });
     let caught = 0;
-    const testStatuses = [304, 400, 401, 403, 404, 422];
+    const testStatuses = [304, 400, 401, 403, 404, 422, 451];
 
     for (const status of testStatuses) {
       try {
@@ -241,7 +241,7 @@ describe("Automatic Retries", function () {
       },
     });
     let caught = 0;
-    const testStatuses = [304, 400, 401, 403, 404];
+    const testStatuses = [304, 400, 401, 403, 404, 422, 451];
 
     for (const status of testStatuses) {
       try {


### PR DESCRIPTION
451 is returned when a resource has been restricted for legal reasons. Retrying this status needlessly wastes API quota.
Here's an example: https://api.github.com/repos/amusi/Python3

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #448

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
API calls resulting in status code 451 would be retried
*

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
API calls resulting in status code 451 are no longer retried
*


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x ] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

