### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Octokit } from "@octokit/core";
 import type { RequestError } from "@octokit/request-error";
 
-import { errorRequest } from "./error-request";
-import { wrapRequest } from "./wrap-request";
+import { errorRequest } from "./error-request.js";
+import { wrapRequest } from "./wrap-request.js";
 
 export const VERSION = "0.0.0-development";
 

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import Bottleneck from "bottleneck/light";
 import { RequestError } from "@octokit/request-error";
-import { errorRequest } from "./error-request";
+import { errorRequest } from "./error-request.js";
 
 export async function wrapRequest(state, octokit, request, options) {
   const limiter = new Bottleneck();

--- a/test/octokit.ts
+++ b/test/octokit.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "@octokit/core";
 import { RequestError } from "@octokit/request-error";
-import { retry } from "../src";
+import { retry } from "../src/index.ts";
 
 function testPlugin(octokit: Octokit) {
   const t0 = Date.now();

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,7 +1,7 @@
-import { TestOctokit } from "./octokit";
-import { errorRequest } from "../src/error-request";
+import { TestOctokit } from "./octokit.ts";
+import { errorRequest } from "../src/error-request.ts";
 import { RequestError } from "@octokit/request-error";
-import { RequestMethod } from "@octokit/types";
+import type { RequestMethod } from "@octokit/types";
 
 describe("Automatic Retries", function () {
   it("Should be possible to disable the plugin", async function () {

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { retry } from "../src";
+import { retry } from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.