### PR TITLE
fix: add missing file extension on bottleneck import

### DIFF
--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import Bottleneck from "bottleneck/light";
+import Bottleneck from "bottleneck/light.js";
 import { RequestError } from "@octokit/request-error";
 import { errorRequest } from "./error-request.js";
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #519

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When importing the package, consumers get a `ERR_MODULE_NOT_FOUND` error from the bottleneck import

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* When importing the package, no errors are thrown

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

