### PR TITLE
Pin @octokit/core peerDependency to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bottleneck": "^2.15.3"
   },
   "peerDependencies": {
-    "@octokit/core": ">=5"
+    "@octokit/core": "5"
   },
   "devDependencies": {
     "@octokit/core": "^5.0.0",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/octokit/plugin-retry.js/issues/521

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  Octokit/core@6 is now ESM, which while this version is still CJS can't pull in and use.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

*  Pinning this back to Octokit/core@5 where it remains CJS fixes this.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

