### PR TITLE
fix: `response.data.errors` is sometimes empty

### DIFF
--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -35,6 +35,7 @@ async function requestWithGraphqlErrorHandling(
   if (
     response.data &&
     response.data.errors &&
+    response.data.errors.length > 0 &&
     /Something went wrong while executing your query/.test(
       response.data.errors[0].message,
     )


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #536

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `request.data.errors` property was always assumed to be a populated array

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Check to see if the array is not empty

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

