### PR TITLE
Retry on HTTP 410

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plugin-retry.js
 
-> Retries requests for server 4xx/5xx responses except `400`, `401`, `403`, `404`, `422`, and `451`.
+> Retries requests for server 4xx/5xx responses except `400`, `401`, `403`, `404`, `410`, `422`, and `451`.
 
 [![@latest](https://img.shields.io/npm/v/@octokit/plugin-retry.svg)](https://www.npmjs.com/package/@octokit/plugin-retry)
 [![Build Status](https://github.com/octokit/plugin-retry.js/workflows/Test/badge.svg)](https://github.com/octokit/plugin-retry.js/actions?workflow=Test)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export function retry(octokit: Octokit, octokitOptions: any) {
     {
       enabled: true,
       retryAfterBaseValue: 1000,
-      doNotRetry: [400, 401, 403, 404, 422, 451],
+      doNotRetry: [400, 401, 403, 404, 410, 422, 451],
       retries: 3,
     },
     octokitOptions.retry,

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -206,10 +206,10 @@ describe("Automatic Retries", function () {
     expect(ms2).toBeGreaterThan(420);
   });
 
-  it("Should not retry 3xx/400/401/403/422/451 errors", async function () {
+  it("Should not retry 3xx/400/401/403/410/422/451 errors", async function () {
     const octokit = new TestOctokit({ retry: { retryAfterBaseValue: 50 } });
     let caught = 0;
-    const testStatuses = [304, 400, 401, 403, 404, 422, 451];
+    const testStatuses = [304, 400, 401, 403, 404, 410, 422, 451];
 
     for (const status of testStatuses) {
       try {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/octokit/plugin-retry.js/issues/620

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Requests returning HTTP 410, resulting in 3x more requests to the API for the default settings, despite the API not returning a different response.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Request which return a 410 status code will not be retried automatically, acting the same as if it returned 404.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

