### PR TITLE
Add option to provide a custom predicate to decide whether to retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ const octokit = new MyOctokit({
 });
 ```
 
+You can override the default predicate that determines whether to retry a request based on the outcome of the previous attempt. For example, to retry if the response message includes a particular string. Note that the `doNotRetry` option from the constructor is ignored in this case.
+
+```typescript
+const octokit = new MyOctokit({
+  auth: "secret123",
+  retry: {
+    shouldRetry: (retryState: RetryState, error: any) => {
+      if (isRequestError(error)) {
+        return error.message.includes("Intermittent problem");
+      }
+      return false;
+    },
+  },
+});
+```
+
 To override the number of retries:
 
 ```js

--- a/src/error-request.ts
+++ b/src/error-request.ts
@@ -6,19 +6,25 @@ export function isRequestError(error: any): error is RequestError {
   return error.request !== undefined;
 }
 
+export function defaultShouldRetry(
+  state: RetryState,
+  error: RequestError | Error,
+): boolean {
+  if (!isRequestError(error) || !error?.request.request) {
+    // address https://github.com/octokit/plugin-retry.js/issues/8
+    throw error;
+  }
+
+  return error.status >= 400 && !state.doNotRetry.includes(error.status);
+}
+
 export async function errorRequest(
   state: RetryState,
   octokit: RetryPlugin,
   error: RequestError | Error,
   options: { request: RequestRequestOptions },
 ): Promise<any> {
-  if (!isRequestError(error) || !error?.request.request) {
-    // address https://github.com/octokit/plugin-retry.js/issues/8
-    throw error;
-  }
-
-  // retry all >= 400 && not doNotRetry
-  if (error.status >= 400 && !state.doNotRetry.includes(error.status)) {
+  if (isRequestError(error) && state.shouldRetry(state, error)) {
     const retries =
       options.request.retries != null ? options.request.retries : state.retries;
     const retryAfter = Math.pow((options.request.retryCount || 0) + 1, 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { Octokit, OctokitOptions } from "@octokit/core";
 import type { RequestError } from "@octokit/request-error";
 
 import { VERSION } from "./version.js";
-import { errorRequest } from "./error-request.js";
+import { defaultShouldRetry, errorRequest } from "./error-request.js";
 import { wrapRequest } from "./wrap-request.js";
 import type { RetryOptions, RetryPlugin, RetryState } from "./types.js";
 import type { RequestRequestOptions } from "@octokit/types";
@@ -18,6 +18,7 @@ export function retry(
       retryAfterBaseValue: 1000,
       doNotRetry: [400, 401, 403, 404, 410, 422, 451],
       retries: 3,
+      shouldRetry: defaultShouldRetry,
     } satisfies RetryState,
     octokitOptions.retry,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,18 +8,21 @@ import type { RetryOptions, RetryPlugin, RetryState } from "./types.js";
 import type { RequestRequestOptions } from "@octokit/types";
 export { VERSION } from "./version.js";
 
+export const defaultRetryState: RetryState = {
+  enabled: true,
+  retryAfterBaseValue: 1000,
+  doNotRetry: [400, 401, 403, 404, 410, 422, 451],
+  retries: 3,
+  shouldRetry: defaultShouldRetry,
+};
+
 export function retry(
   octokit: Octokit,
   octokitOptions: OctokitOptions,
 ): RetryPlugin {
   const state: RetryState = Object.assign(
-    {
-      enabled: true,
-      retryAfterBaseValue: 1000,
-      doNotRetry: [400, 401, 403, 404, 410, 422, 451],
-      retries: 3,
-      shouldRetry: defaultShouldRetry,
-    } satisfies RetryState,
+    {},
+    defaultRetryState,
     octokitOptions.retry,
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,4 +58,11 @@ declare module "@octokit/core/types" {
   }
 }
 
+declare module "@octokit/types" {
+  interface RequestRequestOptions {
+    retries?: number;
+    retryAfter?: number;
+  }
+}
+
 export type { RetryPlugin, RetryOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,15 @@
 import type { Octokit, OctokitOptions } from "@octokit/core";
-import type { RequestError } from "@octokit/request-error";
 
 import { VERSION } from "./version.js";
 import { defaultShouldRetry, errorRequest } from "./error-request.js";
 import { wrapRequest } from "./wrap-request.js";
-import type { RetryOptions, RetryPlugin, RetryState } from "./types.js";
+import type {
+  RequestOptionsWithRequest,
+  RetryOptions,
+  RetryPlugin,
+  RetryRequestOptions,
+  RetryState,
+} from "./types.js";
 import type { RequestRequestOptions } from "@octokit/types";
 export { VERSION } from "./version.js";
 
@@ -29,16 +34,17 @@ export function retry(
   const retryPlugin: RetryPlugin = {
     retry: {
       retryRequest: (
-        error: RequestError,
+        request: RequestOptionsWithRequest,
         retries: number,
         retryAfter: number,
       ) => {
-        error.request.request = Object.assign({}, error.request.request, {
+        const newRequest: RequestRequestOptions &
+          Required<RetryRequestOptions> = Object.assign({}, request.request, {
           retries: retries,
           retryAfter: retryAfter,
-        } satisfies RequestRequestOptions);
+        } as Required<RetryRequestOptions>);
 
-        return error;
+        return { ...request, request: newRequest };
       },
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,24 @@
 import type { RequestError } from "@octokit/request-error";
+import type { RequestOptions, RequestRequestOptions } from "@octokit/types";
+
+export interface RetryRequestOptions {
+  retries?: number;
+  retryAfter?: number;
+}
+
+export type RequestOptionsWithRequest = RequestOptions & {
+  request: RequestRequestOptions & RetryRequestOptions;
+};
 
 export interface RetryPlugin {
   retry: {
     retryRequest: (
-      error: RequestError,
+      request: RequestOptionsWithRequest,
       retries: number,
       retryAfter: number,
-    ) => RequestError;
+    ) => RequestOptions & {
+      request: RequestRequestOptions & Required<RetryRequestOptions>;
+    };
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface RetryOptions {
   retryAfterBaseValue?: number;
   doNotRetry?: number[];
   retries?: number;
+  shouldRetry?: (state: RetryState, error: RequestError | Error) => boolean;
 }
 
 export type RetryState = Required<RetryOptions>;

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -26,6 +26,9 @@ export async function wrapRequest(
       // the request after that number of milliseconds have passed
       return after * state.retryAfterBaseValue;
     }
+
+    // Do not retry.
+    return undefined;
   });
 
   return limiter.schedule(

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -17,8 +17,8 @@ export async function wrapRequest(
   const limiter = new Bottleneck();
 
   limiter.on("failed", function (error: RequestError, info: RetryableInfo) {
-    const maxRetries = ~~error.request.request?.retries;
-    const after = ~~error.request.request?.retryAfter;
+    const maxRetries = error.request.request?.retries || 0;
+    const after = error.request.request?.retryAfter || 0;
     options.request.retryCount = info.retryCount + 1;
 
     if (maxRetries > info.retryCount) {

--- a/test/error-request.test.ts
+++ b/test/error-request.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { defaultShouldRetry } from "../src/error-request.ts";
+import { defaultRetryState } from "../src/index.ts";
+import { RequestError } from "@octokit/request-error";
+
+describe("defaultShouldRetry", function () {
+  it("should re-throw non-RequestError errors", function () {
+    try {
+      defaultShouldRetry(defaultRetryState, new Error("Re-throw me"));
+      throw new Error("Should not reach this point");
+    } catch (err: any) {
+      expect(err.message).toEqual("Re-throw me");
+    }
+  });
+
+  it("should re-throw errors without RequestRequestOptions", function () {
+    try {
+      defaultShouldRetry(
+        defaultRetryState,
+        new RequestError("Re-throw me", 500, {
+          request: { method: "GET", url: "/something", headers: {} },
+        }),
+      );
+      throw new Error("Should not reach this point");
+    } catch (err: any) {
+      expect(err.message).toEqual("Re-throw me");
+    }
+  });
+
+  it("returns false for doNotRetry status codes", function () {
+    for (const statusCode of defaultRetryState.doNotRetry) {
+      const result = defaultShouldRetry(
+        defaultRetryState,
+        new RequestError("Re-throw me", statusCode, {
+          request: {
+            method: "GET",
+            url: "/something",
+            headers: {},
+            request: {},
+          },
+        }),
+      );
+      expect(result).toBe(false);
+    }
+  });
+
+  it("returns true for 500 errors", function () {
+    const result = defaultShouldRetry(
+      defaultRetryState,
+      new RequestError("Re-throw me", 500, {
+        request: {
+          method: "GET",
+          url: "/something",
+          headers: {},
+          request: {},
+        },
+      }),
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { TestOctokit } from "./octokit.ts";
-import { errorRequest, isRequestError } from "../src/error-request.ts";
+import {
+  defaultShouldRetry,
+  errorRequest,
+  isRequestError,
+} from "../src/error-request.ts";
 import { RequestError } from "@octokit/request-error";
 import type {
   RequestMethod,
@@ -414,6 +418,7 @@ describe("errorRequest", function () {
       retryAfterBaseValue: 1000,
       doNotRetry: [400, 401, 403, 404, 422],
       retries: 3,
+      shouldRetry: defaultShouldRetry,
     } satisfies RetryState;
     const requestOptions = {
       method: "GET" as RequestMethod,
@@ -448,6 +453,7 @@ describe("errorRequest", function () {
       retryAfterBaseValue: 1000,
       doNotRetry: [400, 401, 403, 404, 422],
       retries: 3,
+      shouldRetry: defaultShouldRetry,
     } satisfies RetryState;
     const requestOptions = {
       method: "GET" as RequestMethod,


### PR DESCRIPTION
This is a first attempt at adding a new option `shouldRetry` to `RetryOptions`, which accepts a function of type `(state: RetryState, error: RequestError | Error) => boolean`. Setting this overrides the default logic for determining whether a request should be retried based on the outcome of the last attempt. By default, this is set to the existing implementation of:

```typescript
export function defaultShouldRetry(
  state: RetryState,
  error: RequestError | Error,
): boolean {
  if (!isRequestError(error) || !error?.request.request) {
    // address https://github.com/octokit/plugin-retry.js/issues/8
    throw error;
  }

  return error.status >= 400 && !state.doNotRetry.includes(error.status);
}
```

By setting `shouldRetry` to something else, requests can be retried based on criteria other than the status code. For example, to make the decision based on the error message:

```typescript
const octokit = new MyOctokit({
  auth: "secret123",
  retry: {
    shouldRetry: (retryState: RetryState, error: any) => {
      if (isRequestError(error)) {
        return error.message.includes("Intermittent problem");
      }
      return false;
    },
  },
});
```

This will probably need some polish (particularly around typing extensions to `RequestRequestOptions`), but should be good for a first round of review. Best reviewed commit-by-commit. 

A few notes:

- https://github.com/octokit/plugin-retry.js/commit/e1fcc27f7506c4d448d3a4bd8ca0c36f467e5309 adds the new option and starts using it, but restricted to just `RequestError` errors.
- https://github.com/octokit/plugin-retry.js/commit/dc1a8bd1287e455e70a43abd04749dc5ce073a6d then lifts that restriction by changing `retryRequest` to transform the `options` rather than the `error`. A new `RequestError` is then constructed based on that. For non-`RequestError` errors, we don't have a status code, so I use `500` instead similar to what happens in `requestWithGraphqlErrorHandling`.
- I played around with introducing a new error type for "retry requests" that doesn't have this requirement, but it added a bunch more complexity, so I left it like this for now.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Requests will only be retried based on `>= 400` status codes.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* No change if `shouldRetry` is not customised.
* If `shouldRetry` is customised, then requests can be retried on custom criteria.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

There should be no breaking change since `shouldRetry` is optional in `RetryOptions` and uses the previous implementation by default. 

----

