### PR TITLE
fix: augment `@octokit/core` instead of a `@octokit/core/types`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export function retry(
 }
 retry.VERSION = VERSION;
 
-declare module "@octokit/core/types" {
+declare module "@octokit/core" {
   interface OctokitOptions {
     retry?: RetryOptions;
   }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #665

----

### Before the change?

* I was running into some weird implicit anys when combining this plugin with `@octokit/plugin-throttling` 

### After the change?

* The spurious error is no longer reported 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

This PR simply matches the pre-established way of augmenting the Octokit types, see:
https://github.com/octokit/plugin-throttling.js/blob/59b7668b5b492bb60ebd6f9e7a5a0b68ff6b9a1b/src/index.ts#L208-L212